### PR TITLE
experiment spec cluster_def return default standalone mode cluster definition when no specified framework

### DIFF
--- a/polyaxon_schemas/polyaxonfile/specification/experiment.py
+++ b/polyaxon_schemas/polyaxonfile/specification/experiment.py
@@ -123,6 +123,9 @@ class ExperimentSpecification(BaseSpecification):
                 cluster=cluster,
                 pytorch_config=environment.pytorch)
 
+        # No specified framework, It should return default standalone mode cluster definition
+        return cluster, is_distributed
+
     @cached_property
     def total_resources(self):
         environment = self.environment

--- a/tests/fixtures/env_without_framework.yml
+++ b/tests/fixtures/env_without_framework.yml
@@ -1,0 +1,17 @@
+---
+version: 1
+
+kind: experiment
+
+project:
+  name: test
+
+environment:
+  resources:
+    gpu:
+      requests: 1
+      limits: 1
+
+run:
+  image: test
+  cmd: python test.py

--- a/tests/test_polyaxonfile/test_specification.py
+++ b/tests/test_polyaxonfile/test_specification.py
@@ -6,7 +6,8 @@ import os
 from unittest import TestCase
 
 from polyaxon_schemas.exceptions import PolyaxonConfigurationError
-from polyaxon_schemas.polyaxonfile.specification import PluginSpecification
+from polyaxon_schemas.polyaxonfile.specification import ExperimentSpecification, PluginSpecification
+from polyaxon_schemas.utils import TaskType
 
 
 class TestSpecifications(TestCase):
@@ -18,3 +19,7 @@ class TestSpecifications(TestCase):
         with self.assertRaises(PolyaxonConfigurationError):
             PluginSpecification.read(os.path.abspath(
                 'tests/fixtures/plugin_run_exec_simple_file_with_cmd.yml'))
+
+    def test_cluster_def_without_framwork(self):
+        spec = ExperimentSpecification.read(os.path.abspath('tests/fixtures/env_without_framework.yml'))
+        self.assertEqual(spec.cluster_def, ({TaskType.MASTER: 1}, False))


### PR DESCRIPTION
To fix https://github.com/polyaxon/polyaxon/issues/90, these changes should be merged first before fix it in polyaxon repo. I will post another PR for polyaxon later.  