### PR TITLE
fix polyaxon's polyaxonfile config parser

### DIFF
--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -77,7 +77,7 @@ class BuildConfig(BaseConfig):
 
     @property
     def image_tag(self):
-        tagged_image = self.image.split(':')
+        tagged_image = self.image.rsplit(':', 1)
         if len(tagged_image) == 1:
             return 'latest'
 

--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -17,10 +17,8 @@ from polyaxon_schemas.base import BaseConfig
 def validate_image(image):
     if not image:
         raise ValidationError('Invalid docker image `{}`'.format(image))
-    tagged_image = image.rsplit(':')
-    if len(tagged_image) >  3:
-        raise ValidationError('Invalid docker image `{}`'.format(image))
-    if len(tagged_image) > 2:
+    tagged_image = image.split(':')
+    if len(tagged_image) > 3:
         raise ValidationError('Invalid docker image `{}`'.format(image))
 
 
@@ -79,13 +77,13 @@ class BuildConfig(BaseConfig):
 
     @property
     def image_tag(self):
-    tagged_image = self.image.split(':')
-    if len(tagged_image) == 1:
-        return 'latest'
-     if len(tagged_image) == 2:
-         return 'latest' if '/' in tagged_image[-1] else tagged_image[-1] 
-     if len(tagged_image) == 3:
-         return tagged_image[-1]
+        tagged_image = self.image.split(':')
+        if len(tagged_image) == 1:
+            return 'latest'
+        if len(tagged_image) == 2:
+            return 'latest' if '/' in tagged_image[-1] else tagged_image[-1]
+        if len(tagged_image) == 3:
+            return tagged_image[-1]
         if len(tagged_image) == 1:
             return 'latest'
 

--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -17,7 +17,9 @@ from polyaxon_schemas.base import BaseConfig
 def validate_image(image):
     if not image:
         raise ValidationError('Invalid docker image `{}`'.format(image))
-    tagged_image = image.rsplit(':', 1)
+    tagged_image = image.rsplit(':')
+    if len(tagged_image) >  3:
+        raise ValidationError('Invalid docker image `{}`'.format(image))
     if len(tagged_image) > 2:
         raise ValidationError('Invalid docker image `{}`'.format(image))
 

--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -79,7 +79,13 @@ class BuildConfig(BaseConfig):
 
     @property
     def image_tag(self):
-        tagged_image = self.image.rsplit(':', 1)
+    tagged_image = self.image.split(':')
+    if len(tagged_image) == 1:
+        return 'latest'
+     if len(tagged_image) == 2:
+         return 'latest' if '/' in tagged_image[-1] else tagged_image[-1] 
+     if len(tagged_image) == 3:
+         return tagged_image[-1]
         if len(tagged_image) == 1:
             return 'latest'
 

--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -17,7 +17,7 @@ from polyaxon_schemas.base import BaseConfig
 def validate_image(image):
     if not image:
         raise ValidationError('Invalid docker image `{}`'.format(image))
-    tagged_image = image.split(':')
+    tagged_image = image.rsplit(':', 1)
     if len(tagged_image) > 2:
         raise ValidationError('Invalid docker image `{}`'.format(image))
 

--- a/polyaxon_schemas/build.py
+++ b/polyaxon_schemas/build.py
@@ -87,4 +87,4 @@ class BuildConfig(BaseConfig):
         if len(tagged_image) == 1:
             return 'latest'
 
-        return tagged_image[1]
+        return tagged_image[-1]


### PR DESCRIPTION
this eliminates the assumption that a docker image
string can only have 1 colon in it, i.e. where
the registry you're pulling from is accessed by
a port number. we should only split the string by
the rightmost colon.

fix for https://github.com/polyaxon/polyaxon/issues/271