### PR TITLE
Loosen Jinja2 requirement specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
         "kubernetes",
     ],
     install_requires=[
-        "hestia==0.3.1",
-        "Jinja2==2.10.1",
+        "hestia~=0.3.1",
+        "Jinja2~=2.10.1",
         "marshmallow==3.0.0rc5",
         "numpy>=1.15.2",
         "python-dateutil>=2.7.3",


### PR DESCRIPTION
By pinning an exact version of Jinja2, when you don't need an exact version, causes issues with installing and using this tool:

> ERROR: polyaxon-schemas 0.5.6 has requirement Jinja2==2.10.1, but you'll have jinja2 2.10.3 which is incompatible.

When specifying a requirement it is very, very uncommon to pin it to an exact version. Pretty much just don't ever do this. What you _want_ is to say `I want Jinja2 2.10.*`, which is what this MR provides.